### PR TITLE
added support for exposed service and pvc file read-in

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,14 +3,12 @@
 filters:
   ".*":
     reviewers:
-      - rrati
       - msenmurugan
       - jdartigalongue
       - mphammer
       - yashbhutwala
       - VSharapov
     approvers:
-      - rrati
       - msenmurugan
       - jdartigalongue
       - mphammer

--- a/go.sum
+++ b/go.sum
@@ -714,6 +714,7 @@ k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
+k8s.io/apimachinery v0.18.1 h1:hKPYcQRPLQoG2e7fKkVl0YCvm9TBefXTfGILa9vjVVk=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/apiserver v0.17.3/go.mod h1:iJtsPpu1ZpEnHaNawpSV0nYTGBhhX2dUlnn7/QS7QiY=
 k8s.io/cli-runtime v0.17.2 h1:YH4txSplyGudvxjhAJeHEtXc7Tr/16clKGfN076ydGk=

--- a/pkg/blackduck/certificate.go
+++ b/pkg/blackduck/certificate.go
@@ -121,6 +121,7 @@ func CreateSelfSignedCert() (string, string) {
 	return certificate.String(), key.String()
 }
 
+// GetCertificateSecretFromFile generates secret from file
 func GetCertificateSecretFromFile(secretName, namespace, certPath, keyPath string) (*corev1.Secret, error) {
 	cert, err := ioutil.ReadFile(certPath)
 	if err != nil {
@@ -135,6 +136,7 @@ func GetCertificateSecretFromFile(secretName, namespace, certPath, keyPath strin
 	return GetCertificateSecret(secretName, namespace, cert, key)
 }
 
+// GetCertificateSecret get the webserver or nginx certificate secret from file bytes
 func GetCertificateSecret(secretName string, namespace string, cert []byte, key []byte) (*corev1.Secret, error) {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -158,6 +160,7 @@ func GetCertificateSecret(secretName string, namespace string, cert []byte, key 
 	}, nil
 }
 
+// GetProxyCertificateSecret get the proxy certificate secret from file bytes
 func GetProxyCertificateSecret(secretName string, namespace string, cert []byte) (*corev1.Secret, error) {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -180,6 +183,7 @@ func GetProxyCertificateSecret(secretName string, namespace string, cert []byte)
 	}, nil
 }
 
+// GetAuthCertificateSecret get the authentication CA certificate secret from file bytes
 func GetAuthCertificateSecret(secretName string, namespace string, cert []byte) (*corev1.Secret, error) {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/blackduck/conversion.go
+++ b/pkg/blackduck/conversion.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// OperatorAffinityTok8sAffinity converts synopsysctl affinity format to kube affinity format
 func OperatorAffinityTok8sAffinity(opAffinity []v1.NodeAffinity) corev1.Affinity {
 	var hardTerms, softTerms []corev1.NodeSelectorTerm
 	for _, aValue := range opAffinity {
@@ -77,6 +78,7 @@ func OperatorAffinityTok8sAffinity(opAffinity []v1.NodeAffinity) corev1.Affinity
 	return af
 }
 
+// OperatorSecurityContextTok8sAffinity converts synopsysctl security context format to kube affinity format
 func OperatorSecurityContextTok8sAffinity(opSecurityContext api.SecurityContext) corev1.PodSecurityContext {
 	return corev1.PodSecurityContext{
 		FSGroup:    opSecurityContext.FsGroup,
@@ -85,6 +87,7 @@ func OperatorSecurityContextTok8sAffinity(opSecurityContext api.SecurityContext)
 	}
 }
 
+// GetCertsFromFlagsAndSetHelmValue converts synopsysctl certificate files to kube secrets
 func GetCertsFromFlagsAndSetHelmValue(name string, namespace string, flagset *pflag.FlagSet, helmVal map[string]interface{}) ([]corev1.Secret, error) {
 	var objects []corev1.Secret
 	if flagset.Lookup("certificate-file-path").Changed && flagset.Lookup("certificate-key-file-path").Changed {

--- a/pkg/blackduck/service.go
+++ b/pkg/blackduck/service.go
@@ -1,0 +1,158 @@
+/*
+Copyright (C) 2020 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package blackduck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blackducksoftware/synopsysctl/pkg/api"
+	"github.com/blackducksoftware/synopsysctl/pkg/util"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// CRUDServiceOrRoute will create or update Black Duck exposed service or route in case of OpenShift
+func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, isExposedUI interface{}, exposedServiceType interface{}) error {
+	serviceName := util.GetResourceName(name, util.BlackDuckName, "webserver-exposed")
+	routeName := util.GetResourceName(name, util.BlackDuckName, "")
+	isOpenShift := util.IsOpenshift(kubeClient)
+	var err error
+	if isExposedUI != nil && isExposedUI.(bool) {
+		switch exposedServiceType.(string) {
+		case "NodePort":
+			err = crudExposedService(restConfig, kubeClient, namespace, name, corev1.ServiceTypeNodePort)
+			if err != nil {
+				return err
+			}
+		case "LoadBalancer":
+			err = crudExposedService(restConfig, kubeClient, namespace, name, corev1.ServiceTypeLoadBalancer)
+			if err != nil {
+				return err
+			}
+		case "OpenShift":
+			if _, err = util.GetService(kubeClient, namespace, serviceName); err == nil {
+				err = util.DeleteService(kubeClient, namespace, serviceName)
+				if err != nil {
+					return fmt.Errorf("unable to delete the Black Duck webserver expose service due to %+v", err)
+				}
+			}
+			routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
+			if _, err = util.GetRoute(routeClient, namespace, routeName); err != nil && !k8serrors.IsAlreadyExists(err) {
+				openShiftRoute := GetWebServerRoute(namespace, routeName, name)
+				_, err := util.CreateRoute(routeClient, namespace, openShiftRoute)
+				if err != nil {
+					return fmt.Errorf("failed to create Black Duck webserver route due to %+v", err)
+				}
+			}
+		}
+	} else {
+		if isOpenShift {
+			routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
+			if _, err = util.GetRoute(routeClient, namespace, routeName); err == nil {
+				err = util.DeleteRoute(routeClient, namespace, routeName)
+				if err != nil {
+					return fmt.Errorf("unable to delete Black Duck webserver route due to %+v", err)
+				}
+			}
+		} else {
+			if _, err = util.GetService(kubeClient, namespace, serviceName); err == nil {
+				err = util.DeleteService(kubeClient, namespace, serviceName)
+				if err != nil {
+					return fmt.Errorf("unable to delete the Black Duck webserver expose service due to %+v", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// crudExposedService crud for webserver exposed service
+func crudExposedService(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, serviceType corev1.ServiceType) error {
+	serviceName := util.GetResourceName(name, util.BlackDuckName, "webserver-exposed")
+	routeName := util.GetResourceName(name, util.BlackDuckName, "")
+	isOpenShift := util.IsOpenshift(kubeClient)
+	if isOpenShift {
+		routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
+		if _, err := util.GetRoute(routeClient, namespace, routeName); err == nil {
+			err = util.DeleteRoute(routeClient, namespace, routeName)
+			if err != nil {
+				return fmt.Errorf("unable to delete Black Duck webserver route due to %+v", err)
+			}
+		}
+	}
+	if svc, err := util.GetService(kubeClient, namespace, serviceName); err == nil {
+		if !strings.EqualFold(string(svc.Spec.Type), string(serviceType)) {
+			svc.Spec.Type = serviceType
+			if _, err = util.UpdateService(kubeClient, namespace, svc); err != nil {
+				return fmt.Errorf("failed to update Black Duck webserver exposed service due to %+v", err)
+			}
+		}
+	} else {
+		service := GetWebServerExposedService(namespace, serviceName, name, serviceType)
+		_, err = util.CreateKubeService(kubeClient, namespace, service)
+		if err != nil {
+			return fmt.Errorf("failed to create Black Duck webserver exposed service due to %+v", err)
+		}
+	}
+	return nil
+}
+
+// GetWebServerExposedService return the Kubernetes service
+func GetWebServerExposedService(namespace string, serviceName string, name string, serviceType corev1.ServiceType) *corev1.Service {
+	return util.GetKubeService(
+		namespace,
+		name,
+		map[string]string{
+			"app":       util.BlackDuckName,
+			"component": "webserver-exposed",
+			"name":      name,
+		},
+		map[string]string{
+			"app":       util.BlackDuckName,
+			"component": "webserver",
+			"name":      name,
+		},
+		int32(443),
+		"8443",
+		serviceType,
+	)
+}
+
+// GetWebServerRoute return the OpenShift route
+func GetWebServerRoute(namespace string, routeName string, name string) *routev1.Route {
+	return util.GetRouteComponent(
+		&api.Route{
+			Name:               routeName,
+			Namespace:          namespace,
+			Kind:               "Service",
+			ServiceName:        util.GetResourceName(name, util.BlackDuckName, "webserver"),
+			PortName:           fmt.Sprintf("port-%d", 443),
+			Labels:             map[string]string{"app": util.BlackDuckName, "name": name, "component": "route"},
+			TLSTerminationType: routev1.TLSTerminationPassthrough,
+		},
+		map[string]string{"app": util.BlackDuckName, "name": name, "component": "route"},
+	)
+}

--- a/pkg/crdupdater/route.go
+++ b/pkg/crdupdater/route.go
@@ -82,7 +82,7 @@ func (c *Route) buildNewAndOldObject() error {
 
 	// build new route
 	for i, newRoute := range c.routes {
-		newRouteKube := util.GetRouteComponent(c.routeClient, newRoute, c.routes[i].Labels)
+		newRouteKube := util.GetRouteComponent(newRoute, c.routes[i].Labels)
 		c.newRoutes[newRoute.Name] = newRouteKube
 	}
 	return nil

--- a/pkg/synopsysctl/blackduck_migrate.go
+++ b/pkg/synopsysctl/blackduck_migrate.go
@@ -102,6 +102,11 @@ func migrate(bd *v1.Blackduck, operatorNamespace string, crdNamespace string, fl
 		return fmt.Errorf("failed to create Blackduck resources: %+v", err)
 	}
 
+	err = blackduck.CRUDServiceOrRoute(restconfig, kubeClient, bd.Spec.Namespace, bd.Name, helmValuesMap["exposeui"], helmValuesMap["exposedServiceType"])
+	if err != nil {
+		return err
+	}
+
 	log.Info("removing Black Duck custom resource")
 	if err := util.DeleteBlackduck(blackDuckClient, bd.Name, bd.Namespace, &metav1.DeleteOptions{}); err != nil {
 		return err


### PR DESCRIPTION
* add CRUD support for Black Duck exposed service and OpenShift routes
* read in pvc-file-path and set the PVC's
* fix the delete Black Duck step
* fixed the reading of old values from the release during update Black Duck 