### PR TITLE
fix for migrate mode for deleting an existing service

### DIFF
--- a/pkg/alert/service.go
+++ b/pkg/alert/service.go
@@ -29,7 +29,7 @@ import (
 )
 
 // CRUDServiceOrRoute will create or update Alert exposed service, or route in case of OpenShift
-func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, isExposedUI interface{}, exposedServiceType interface{}, isMigrate bool) error {
+func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, isExposedUI interface{}, exposedServiceType interface{}, isChanged bool) error {
 	serviceName := util.GetResourceName(name, util.AlertName, "exposed")
 	routeName := util.GetResourceName(name, util.AlertName, "")
 	isOpenShift := util.IsOpenshift(kubeClient)
@@ -58,7 +58,7 @@ func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientse
 			}
 		}
 	} else {
-		if isMigrate {
+		if isChanged {
 			if isOpenShift {
 				routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
 				if _, err = util.GetRoute(routeClient, namespace, routeName); err == nil {

--- a/pkg/blackduck/service.go
+++ b/pkg/blackduck/service.go
@@ -32,7 +32,7 @@ import (
 )
 
 // CRUDServiceOrRoute will create or update Black Duck exposed service or route in case of OpenShift
-func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, isExposedUI interface{}, exposedServiceType interface{}, isMigrate bool) error {
+func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string, name string, isExposedUI interface{}, exposedServiceType interface{}, isChanged bool) error {
 	serviceName := util.GetResourceName(name, util.BlackDuckName, "webserver-exposed")
 	routeName := util.GetResourceName(name, util.BlackDuckName, "")
 	isOpenShift := util.IsOpenshift(kubeClient)
@@ -61,7 +61,7 @@ func CRUDServiceOrRoute(restConfig *rest.Config, kubeClient *kubernetes.Clientse
 			}
 		}
 	} else {
-		if isMigrate {
+		if isChanged {
 			if isOpenShift {
 				routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
 				if _, err = util.GetRoute(routeClient, namespace, routeName); err == nil {

--- a/pkg/synopsysctl/alert_migrate.go
+++ b/pkg/synopsysctl/alert_migrate.go
@@ -200,8 +200,7 @@ func migrateAlert(alert *v1.Alert, operatorNamespace string, crdNamespace string
 	}
 
 	// Update exposed Services for Alert
-	exposeUI := flags.Lookup("expose-ui").Changed && flags.Lookup("expose-ui").Value.String() != util.NONE
-	err = alertctl.CRUDServiceOrRoute(restconfig, kubeClient, namespace, newReleaseName, exposeUI, helmValuesMap["exposedServiceType"], true)
+	err = alertctl.CRUDServiceOrRoute(restconfig, kubeClient, namespace, newReleaseName, helmValuesMap["exposeui"], helmValuesMap["exposedServiceType"], flags.Lookup("expose-ui").Changed)
 	if err != nil {
 		return fmt.Errorf("failed to update Alert's exposed service %+v", err)
 	}

--- a/pkg/synopsysctl/blackduck_migrate.go
+++ b/pkg/synopsysctl/blackduck_migrate.go
@@ -125,7 +125,7 @@ func migrate(bd *v1.Blackduck, operatorNamespace string, crdNamespace string, fl
 		return fmt.Errorf("failed to create Blackduck resources: %+v", err)
 	}
 
-	err = blackduck.CRUDServiceOrRoute(restconfig, kubeClient, bd.Spec.Namespace, bd.Name, helmValuesMap["exposeui"], helmValuesMap["exposedServiceType"], true)
+	err = blackduck.CRUDServiceOrRoute(restconfig, kubeClient, bd.Spec.Namespace, bd.Name, helmValuesMap["exposeui"], helmValuesMap["exposedServiceType"], flags.Lookup("expose-ui").Changed)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* fixed the deletion of service for migrated Black Duck or Alert instance …
* added validation to install or upgrade Black Duck from 2020.4.0 and above