### PR TITLE
Import auth clients for kubeclient to access gcp

### DIFF
--- a/pkg/synopsysctl/cmd_root.go
+++ b/pkg/synopsysctl/cmd_root.go
@@ -30,6 +30,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	// get auth clients for gcp
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // Root Command Options and Defaults


### PR DESCRIPTION
This line used to be in protoform/controller.go:
```
log "github.com/sirupsen/logrus" //_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
```