### PR TITLE
stop and start pass user's set values into upgrade

### DIFF
--- a/pkg/synopsysctl/cmd_start.go
+++ b/pkg/synopsysctl/cmd_start.go
@@ -71,7 +71,8 @@ var startAlertCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := map[string]interface{}{"status": "Running"}
+		helmValuesMap := instance.Config
+		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Running")
 
 		err = util.UpdateWithHelm3(helmReleaseName, namespace, alertChartRepository, helmValuesMap, kubeConfigPath)
 		if err != nil {
@@ -113,7 +114,7 @@ var startBlackDuckCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := make(map[string]interface{})
+		helmValuesMap := instance.Config
 		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Running")
 
 		err = util.UpdateWithHelm3(args[0], namespace, blackduckChartRepository, helmValuesMap, kubeConfigPath)
@@ -152,7 +153,7 @@ var startOpsSightCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := make(map[string]interface{})
+		helmValuesMap := instance.Config
 		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Running")
 
 		err = util.UpdateWithHelm3(opssightName, namespace, opssightChartRepository, helmValuesMap, kubeConfigPath)

--- a/pkg/synopsysctl/cmd_stop.go
+++ b/pkg/synopsysctl/cmd_stop.go
@@ -71,7 +71,8 @@ var stopAlertCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := map[string]interface{}{"status": "Stopped"}
+		helmValuesMap := instance.Config
+		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Stopped")
 
 		err = util.UpdateWithHelm3(helmReleaseName, namespace, alertChartRepository, helmValuesMap, kubeConfigPath)
 		if err != nil {
@@ -112,7 +113,7 @@ var stopBlackDuckCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := make(map[string]interface{})
+		helmValuesMap := instance.Config
 		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Stopped")
 
 		err = util.UpdateWithHelm3(args[0], namespace, blackduckChartRepository, helmValuesMap, kubeConfigPath)
@@ -151,7 +152,7 @@ var stopOpsSightCmd = &cobra.Command{
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
 
-		helmValuesMap := make(map[string]interface{})
+		helmValuesMap := instance.Config
 		util.SetHelmValueInMap(helmValuesMap, []string{"status"}, "Stopped")
 
 		err = util.UpdateWithHelm3(opssightName, namespace, opssightChartRepository, helmValuesMap, kubeConfigPath)

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -450,6 +450,14 @@ func GetValueFromRelease(release *release.Release, keyList []string) interface{}
 	return GetHelmValueFromMap(releaseValues, keyList)
 }
 
+// GetReleaseValues merges the default Chart Values with the user's set values
+// and retuns that set of values
+func GetReleaseValues(release *release.Release) map[string]interface{} {
+	chartValues := release.Chart.Values
+	userConfig := release.Config
+	return MergeMaps(chartValues, userConfig)
+}
+
 // MergeMaps Copied from https://github.com/helm/helm/blob/9b42702a4bced339ff424a78ad68dd6be6e1a80a/pkg/cli/values/options.go#L88
 func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(a))


### PR DESCRIPTION
Fixes missing tlsCertSecretName bug:
* Black Duck was throwing an error during the stop command due to tlsCertSecretName not being set

fixes #53 