### PR TITLE
Bug Fix - Security Context Stop BlackDuck

### DIFF
--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -463,6 +463,10 @@ func runBlackDuckFileOwnershipJobs(blackDuckName, blackDuckNamespace, oldVersion
 		if strings.ToUpper(currState) != "STOPPED" {
 			log.Infof("stopping Black Duck to apply Security Context changes")
 			tmpValuesMap := make(map[string]interface{})
+			err = util.DeepCopyHelmValuesMap(helmReleaseValues, tmpValuesMap) // don't update actual values so the Update Command will restart the instance
+			if err != nil {
+				return fmt.Errorf("failed to deep copy values for stopping Black Duck: %+v", err)
+			}
 			util.SetHelmValueInMap(tmpValuesMap, []string{"status"}, "Stopped")
 			err = util.UpdateWithHelm3(blackDuckName, namespace, blackduckChartRepository, tmpValuesMap, kubeConfigPath)
 			if err != nil {

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -455,6 +455,19 @@ func GetValueFromRelease(release *release.Release, keyList []string) interface{}
 	return GetHelmValueFromMap(releaseValues, keyList)
 }
 
+// DeepCopyHelmValuesMap copies the src map to the dest map. Values in new map have different pointers/references
+func DeepCopyHelmValuesMap(src map[string]interface{}, dest map[string]interface{}) error {
+	jsonStr, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(jsonStr, &dest)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetReleaseValues merges the default Chart Values with the user's set values
 // and retuns that set of values
 func GetReleaseValues(release *release.Release) map[string]interface{} {


### PR DESCRIPTION
while stopping for security context changes, pass all values to UpdateWithHelm so it sees the tlsCertSecretName