### PR TITLE
Ensure the name of extra files is all lowercase for Black Duck size

### DIFF
--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -245,7 +245,7 @@ func (ctl *HelmValuesFromCobraFlags) AddHelmValueByCobraFlag(f *pflag.Flag) {
 		case "version":
 			util.SetHelmValueInMap(ctl.args, []string{"imageTag"}, ctl.flagTree.Version)
 		case "size":
-			util.SetHelmValueInMap(ctl.args, []string{"size"}, ctl.flagTree.Size)
+			util.SetHelmValueInMap(ctl.args, []string{"size"}, strings.ToLower(ctl.flagTree.Size))
 		case "expose-ui":
 			util.SetHelmValueInMap(ctl.args, []string{"exposeui"}, true)
 			switch ctl.flagTree.ExposeService {

--- a/pkg/synopsysctl/blackduck_migrate.go
+++ b/pkg/synopsysctl/blackduck_migrate.go
@@ -92,7 +92,7 @@ func migrate(bd *v1.Blackduck, operatorNamespace string, crdNamespace string, fl
 	var extraFiles []string
 	size, found := helmValuesMap["size"]
 	if found {
-		extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", size.(string)))
+		extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", strings.ToLower(size.(string))))
 	}
 
 	secrets, err := blackduck.GetCertsFromFlagsAndSetHelmValue(bd.Name, namespace, flags, helmValuesMap)
@@ -404,7 +404,7 @@ func blackDuckV1ToHelm(bd *v1.Blackduck, operatorNamespace string) (map[string]i
 		util.SetHelmValueInMap(helmConfig, []string{"webapp", "persistentVolumeClaimName"}, fmt.Sprintf("%s-blackduck-webapp", bd.Name))
 	}
 
-	util.SetHelmValueInMap(helmConfig, []string{"size"}, bd.Spec.Size)
+	util.SetHelmValueInMap(helmConfig, []string{"size"}, strings.ToLower(bd.Spec.Size))
 
 	// expose service
 	util.SetHelmValueInMap(helmConfig, []string{"exposeui"}, false)

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -352,7 +352,7 @@ var createBlackDuckCmd = &cobra.Command{
 		var extraFiles []string
 		size, found := helmValuesMap["size"]
 		if found {
-			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", size.(string)))
+			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", strings.ToLower(size.(string))))
 		}
 
 		// Check Dry Run before deploying any resources
@@ -446,7 +446,7 @@ var createBlackDuckNativeCmd = &cobra.Command{
 		var extraFiles []string
 		size, found := helmValuesMap["size"]
 		if found {
-			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", size.(string)))
+			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", strings.ToLower(size.(string))))
 		}
 
 		// Check Dry Run before deploying any resources

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -344,6 +344,8 @@ var updateBlackDuckCmd = &cobra.Command{
 				}
 			}
 
+			sizeYAMLFileNameInChart = strings.ToLower(sizeYAMLFileNameInChart)
+
 			if len(sizeYAMLFileNameInChart) > 0 {
 				sizeValuesFromChart, err := util.ConvertFilesFromChartToMap(namespace, kubeConfigPath, blackduckChartRepository, sizeYAMLFileNameInChart)
 				if err != nil {


### PR DESCRIPTION
```
BLACK DUCK MIGRATION
=== RUN   TestMigrateBlackDuck
Deploying Synopsys Operator
[/Users/hammer/go/src/github.com/blackducksoftware/synopsysctl/cmd/synopsysctl/synopsysctl_operator deploy --cluster-scoped --enable-blackduck --enable-alert]
Creating Black Duck with Synopsys Operator
[/Users/hammer/go/src/github.com/blackducksoftware/synopsysctl/cmd/synopsysctl/synopsysctl_operator create blackduck bd -n mybd-202051513476 --admin-password pass --user-password pass --postgres-password pass --seal-key abcdefghijklmnopqrstuvwxyz123456 --certificate-file-path /Users/hammer/_payload_blackduck/tls.crt --certificate-key-file-path /Users/hammer/_payload_blackduck/tls.key]
Migrating Black Duck
[synopsysctl update blackduck bd -n mybd-202051513476 --version 2020.4.1]
Wait until Black Duck is Ready
Verifying Black Duck Configuration
Deleting Black Duck
[synopsysctl delete blackduck bd -n mybd-202051513476]
Deleting Black Duck Namespace
Deleting Synopsys Operator Namespace
--- PASS: TestMigrateBlackDuck (207.53s)
PASS
ok  	command-line-arguments	207.754s
```