### PR TITLE
Fix OpsSight ImageTag 

### DIFF
--- a/pkg/opssight/ctl_opssight.go
+++ b/pkg/opssight/ctl_opssight.go
@@ -249,7 +249,8 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 			log.Debugf("flag '%s': CHANGED", f.Name)
 			switch f.Name {
 			case "version":
-				util.SetHelmValueInMap(ctl.args, []string{"imageTag"}, ctl.flagTree.Version)
+				splitVersion := strings.Split(ctl.flagTree.Version, "-")
+				util.SetHelmValueInMap(ctl.args, []string{"imageTag"}, splitVersion[0])
 			case "deployment-resources-file-path":
 				util.GetDeploymentResources(ctl.flagTree.DeploymentResourcesFilePath, ctl.args, "heapMaxMemory") // OpsSight doens't currently use heapMaxMemory
 			// case "is-upstream":

--- a/pkg/opssight/ctl_opssight.go
+++ b/pkg/opssight/ctl_opssight.go
@@ -249,8 +249,7 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 			log.Debugf("flag '%s': CHANGED", f.Name)
 			switch f.Name {
 			case "version":
-				splitVersion := strings.Split(ctl.flagTree.Version, "-")
-				util.SetHelmValueInMap(ctl.args, []string{"imageTag"}, splitVersion[0])
+				util.SetHelmValueInMap(ctl.args, []string{"imageTag"}, ctl.flagTree.Version)
 			case "deployment-resources-file-path":
 				util.GetDeploymentResources(ctl.flagTree.DeploymentResourcesFilePath, ctl.args, "heapMaxMemory") // OpsSight doens't currently use heapMaxMemory
 			// case "is-upstream":

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -491,7 +491,8 @@ var createOpsSightCmd = &cobra.Command{
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
@@ -546,7 +547,8 @@ var createOpsSightNativeCmd = &cobra.Command{
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_start.go
+++ b/pkg/synopsysctl/cmd_start.go
@@ -147,8 +147,9 @@ var startOpsSightCmd = &cobra.Command{
 		}
 
 		// Update the Helm Chart Location
-		opssightVersion := util.GetValueFromRelease(instance, []string{"imageTag"})
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion.(string), &opssightChartRepository)
+		opssightImageTag := util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_start.go
+++ b/pkg/synopsysctl/cmd_start.go
@@ -147,9 +147,9 @@ var startOpsSightCmd = &cobra.Command{
 		}
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		opssightVersion = util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_stop.go
+++ b/pkg/synopsysctl/cmd_stop.go
@@ -146,9 +146,9 @@ var stopOpsSightCmd = &cobra.Command{
 		}
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		opssightVersion = util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_stop.go
+++ b/pkg/synopsysctl/cmd_stop.go
@@ -146,8 +146,9 @@ var stopOpsSightCmd = &cobra.Command{
 		}
 
 		// Update the Helm Chart Location
-		opssightVersion := util.GetValueFromRelease(instance, []string{"imageTag"})
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion.(string), &opssightChartRepository)
+		opssightImageTag := util.GetValueFromRelease(instance, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -868,7 +868,8 @@ var updateOpsSightCmd = &cobra.Command{
 		updateOpsSightCobraHelper.SetArgs(helmRelease.Config)
 
 		// Update the Helm Chart Location
-		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -938,7 +939,8 @@ var updateOpsSightExternalHostCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1023,7 +1025,8 @@ var updateOpsSightExternalHostNativeCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1095,7 +1098,8 @@ var updateOpsSightAddRegistryCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1156,7 +1160,8 @@ var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
+		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -868,12 +868,12 @@ var updateOpsSightCmd = &cobra.Command{
 		updateOpsSightCobraHelper.SetArgs(helmRelease.Config)
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
@@ -939,12 +939,12 @@ var updateOpsSightExternalHostCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
@@ -1025,12 +1025,12 @@ var updateOpsSightExternalHostNativeCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
@@ -1098,12 +1098,12 @@ var updateOpsSightAddRegistryCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}
@@ -1160,12 +1160,12 @@ var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 		helmValuesMap := helmRelease.Config
 
 		// Update the Helm Chart Location
-		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
-		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, opssightVersion, &opssightChartRepository)
+		chartVersion := opssightVersionToChartVersion[opssightVersion]
+		err = SetHelmChartLocation(cmd.Flags(), opssightChartName, chartVersion, &opssightChartRepository)
 		if err != nil {
 			return fmt.Errorf("failed to set the app resources location due to %+v", err)
 		}

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -869,7 +869,7 @@ var updateOpsSightCmd = &cobra.Command{
 
 		// Update the Helm Chart Location
 		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -940,7 +940,7 @@ var updateOpsSightExternalHostCmd = &cobra.Command{
 
 		// Update the Helm Chart Location
 		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1026,7 +1026,7 @@ var updateOpsSightExternalHostNativeCmd = &cobra.Command{
 
 		// Update the Helm Chart Location
 		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1099,7 +1099,7 @@ var updateOpsSightAddRegistryCmd = &cobra.Command{
 
 		// Update the Helm Chart Location
 		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}
@@ -1161,7 +1161,7 @@ var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 
 		// Update the Helm Chart Location
 		opssightImageTag := util.GetValueFromRelease(helmRelease, []string{"imageTag"}).(string)
-		opssightVersion := opssightVersionToChartVersion[opssightImageTag]
+		opssightVersion = opssightVersionToChartVersion[opssightImageTag]
 		if cmd.Flags().Lookup("version").Changed {
 			opssightVersion = cmd.Flags().Lookup("version").Value.String()
 		}

--- a/pkg/synopsysctl/constants.go
+++ b/pkg/synopsysctl/constants.go
@@ -58,6 +58,9 @@ var alertChartName = "synopsys-alert"
 var alertChartRepository = fmt.Sprintf("%s/%s-%s.tgz", baseChartRepository, alertChartName, alertVersion)
 
 // Opssight Helm Chart Constants
+var opssightVersionToChartVersion = map[string]string{
+	"2.2.5": "2.2.5-1",
+}
 var opssightVersion = "2.2.5-1"
 var opssightChartName = "blackduck-connector"
 var opssightChartRepository = fmt.Sprintf("%s/%s-%s.tgz", baseChartRepository, opssightChartName, opssightVersion)


### PR DESCRIPTION
Test Commands:
* ./synopsysctl create opssight black-ops -n opssight-2020519151331 --version 2.2.5
* ./synopsysctl stop opssight black-ops -n opssight-2020519151331
* ./synopsysctl start opssight black-ops -n opssight-2020519151331
* ./synopsysctl update opssight black-ops -n opssight-2020519151331
* ./synopsysctl delete opssight black-ops -n opssight-2020519151331