### PR TITLE
CLOUD-1052: support for proxy and LDAP password

### DIFF
--- a/pkg/blackduck/certificate.go
+++ b/pkg/blackduck/certificate.go
@@ -160,8 +160,8 @@ func GetCertificateSecret(secretName string, namespace string, cert []byte, key 
 	}, nil
 }
 
-// GetProxyCertificateSecret get the proxy certificate secret from file bytes
-func GetProxyCertificateSecret(secretName string, namespace string, cert []byte) (*corev1.Secret, error) {
+// GetSecret get the secret from file bytes
+func GetSecret(secretName string, namespace string, cert []byte, certKey string) (*corev1.Secret, error) {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -177,30 +177,7 @@ func GetProxyCertificateSecret(secretName string, namespace string, cert []byte)
 			},
 		},
 		Data: map[string][]byte{
-			"HUB_PROXY_CERT_FILE": cert,
-		},
-		Type: corev1.SecretTypeOpaque,
-	}, nil
-}
-
-// GetAuthCertificateSecret get the authentication CA certificate secret from file bytes
-func GetAuthCertificateSecret(secretName string, namespace string, cert []byte) (*corev1.Secret, error) {
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app":       "blackduck",
-				"component": "secret",
-				"name":      secretName,
-			},
-		},
-		Data: map[string][]byte{
-			"AUTH_CUSTOM_CA": cert,
+			certKey: cert,
 		},
 		Type: corev1.SecretTypeOpaque,
 	}, nil

--- a/pkg/blackduck/conversion.go
+++ b/pkg/blackduck/conversion.go
@@ -159,7 +159,7 @@ func GetCertsFromFlagsAndSetHelmValue(name string, namespace string, flagset *pf
 			return nil, err
 		}
 
-		secret, err := GetProxyCertificateSecret(secretName, namespace, cert)
+		secret, err := GetSecret(secretName, namespace, cert, "HUB_PROXY_CERT_FILE")
 		if err != nil {
 			return nil, err
 		}
@@ -176,11 +176,45 @@ func GetCertsFromFlagsAndSetHelmValue(name string, namespace string, flagset *pf
 			return nil, err
 		}
 
-		secret, err := GetAuthCertificateSecret(secretName, namespace, cert)
+		secret, err := GetSecret(secretName, namespace, cert, "AUTH_CUSTOM_CA")
 		if err != nil {
 			return nil, err
 		}
 		util.SetHelmValueInMap(helmVal, []string{"certAuthCACertSecretName"}, secretName)
+		objects = append(objects, *secret)
+	}
+
+	if flagset.Lookup("proxy-password-file-path").Changed {
+		certPath := flagset.Lookup("proxy-password-file-path").Value.String()
+		secretName := util.GetResourceName(name, util.BlackDuckName, "proxy-password")
+
+		cert, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, err
+		}
+
+		secret, err := GetSecret(secretName, namespace, cert, "HUB_PROXY_PASSWORD_FILE")
+		if err != nil {
+			return nil, err
+		}
+		util.SetHelmValueInMap(helmVal, []string{"proxyPasswordSecretName"}, secretName)
+		objects = append(objects, *secret)
+	}
+
+	if flagset.Lookup("ldap-password-file-path").Changed {
+		certPath := flagset.Lookup("ldap-password-file-path").Value.String()
+		secretName := util.GetResourceName(name, util.BlackDuckName, "ldap-password")
+
+		cert, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, err
+		}
+
+		secret, err := GetSecret(secretName, namespace, cert, "LDAP_TRUST_STORE_PASSWORD_FILE")
+		if err != nil {
+			return nil, err
+		}
+		util.SetHelmValueInMap(helmVal, []string{"ldapPasswordSecretName"}, secretName)
 		objects = append(objects, *secret)
 	}
 

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -81,6 +81,8 @@ type FlagTree struct {
 	CertificateKeyFilePath   string
 	ProxyCertificateFilePath string
 	AuthCustomCAFilePath     string
+	ProxyPasswordFilePath    string
+	LdapPasswordFilePath     string
 
 	SealKey string
 
@@ -207,7 +209,9 @@ func (ctl *HelmValuesFromCobraFlags) AddCobraFlagsToCommand(cmd *cobra.Command, 
 	cmd.Flags().StringVar(&ctl.flagTree.CertificateFilePath, "certificate-file-path", defaults.CertificateFilePath, "Absolute path to a file for the Black Duck nginx certificate")
 	cmd.Flags().StringVar(&ctl.flagTree.CertificateKeyFilePath, "certificate-key-file-path", defaults.CertificateKeyFilePath, "Absolute path to a file for the Black Duck nginx certificate key")
 	cmd.Flags().StringVar(&ctl.flagTree.ProxyCertificateFilePath, "proxy-certificate-file-path", defaults.ProxyCertificateFilePath, "Absolute path to a file for the Black Duck proxy server’s Certificate Authority (CA)")
-	cmd.Flags().StringVar(&ctl.flagTree.AuthCustomCAFilePath, "auth-custom-ca-file-path", defaults.AuthCustomCAFilePath, "Absolute path to a file for the Custom Auth CA for Black Duck\n")
+	cmd.Flags().StringVar(&ctl.flagTree.AuthCustomCAFilePath, "auth-custom-ca-file-path", defaults.AuthCustomCAFilePath, "Absolute path to a file for the Certificate authentication using custom CA for Black Duck")
+	cmd.Flags().StringVar(&ctl.flagTree.ProxyPasswordFilePath, "proxy-password-file-path", defaults.ProxyPasswordFilePath, "Absolute path to a file for the Proxy Password for Black Duck")
+	cmd.Flags().StringVar(&ctl.flagTree.LdapPasswordFilePath, "ldap-password-file-path", defaults.LdapPasswordFilePath, "Absolute path to a file for the LDAP Password for Black Duck\n")
 
 	// Seal Key
 	if isCreateCmd {

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -318,6 +318,10 @@ func (ctl *HelmValuesFromCobraFlags) VerifyChartVersionSupportsChangedFlags(flag
 	if (flagset.Lookup("redis-max-total").Changed || flagset.Lookup("redis-max-idle").Changed) && (util.CompareVersions(version, "2020.10.0") < 0) {
 		return fmt.Errorf("--redis-max-total or --redis-max-idle is not supported in Black Duck versions before 2020.10.0")
 	}
+
+	if (flagset.Lookup("proxy-password-file-path").Changed || flagset.Lookup("ldap-password-file-path").Changed) && (util.CompareVersions(version, "2020.12.0") < 0) {
+		return fmt.Errorf("--proxy-password-file-path or --ldap-password-file-path is not supported in Black Duck versions before 2020.12.0")
+	}
 	return nil
 }
 

--- a/pkg/synopsysctl/blackduck_migrate.go
+++ b/pkg/synopsysctl/blackduck_migrate.go
@@ -270,7 +270,7 @@ func blackDuckV1ToHelm(bd *v1.Blackduck, operatorNamespace string) (map[string]i
 	// Auth CA
 	if len(bd.Spec.AuthCustomCA) > 0 {
 		authSecretName := util.GetResourceName(bd.Name, util.BlackDuckName, "auth-custom-ca")
-		authSecret, err := blackduck.GetAuthCertificateSecret(authSecretName, bd.Spec.Namespace, []byte(bd.Spec.AuthCustomCA))
+		authSecret, err := blackduck.GetSecret(authSecretName, bd.Spec.Namespace, []byte(bd.Spec.AuthCustomCA), "AUTH_CUSTOM_CA")
 		if err != nil {
 			return nil, err
 		}
@@ -284,7 +284,7 @@ func blackDuckV1ToHelm(bd *v1.Blackduck, operatorNamespace string) (map[string]i
 	// Proxy Cert
 	if len(bd.Spec.ProxyCertificate) > 0 {
 		proxySecretName := util.GetResourceName(bd.Name, util.BlackDuckName, "proxy-certificate")
-		proxySecret, err := blackduck.GetProxyCertificateSecret(proxySecretName, bd.Spec.Namespace, []byte(bd.Spec.ProxyCertificate))
+		proxySecret, err := blackduck.GetSecret(proxySecretName, bd.Spec.Namespace, []byte(bd.Spec.ProxyCertificate), "HUB_PROXY_CERT_FILE")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -359,6 +359,7 @@ var updateBlackDuckCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+			// Create or update the secret based on the certificate/password file path is set
 			isSecretUpdated := false
 			for _, v := range secrets {
 				if secret, err := util.GetSecret(kubeClient, namespace, v.Name); err == nil {
@@ -375,6 +376,7 @@ var updateBlackDuckCmd = &cobra.Command{
 				isSecretUpdated = true
 			}
 
+			// Whenever the secrets are created/updated, delete the corresponding pods to input the created/updated secrets
 			if isSecretUpdated {
 				labelSelectors := []string{
 					"component=authentication",


### PR DESCRIPTION
* added support for proxy and LDAP password
* added fix for CLOUD-1056 to update the secret and restart pods during update event