### PR TITLE
HUB-28410: adds is-azure flag

### DIFF
--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -233,7 +233,7 @@ func (ctl *HelmValuesFromCobraFlags) AddCobraFlagsToCommand(cmd *cobra.Command, 
 	// Extra Config Settings
 	cmd.Flags().StringVar(&ctl.flagTree.NodeAffinityFilePath, "node-affinity-file-path", defaults.NodeAffinityFilePath, "Absolute path to a file containing a list of node affinities")
 	cmd.Flags().StringVar(&ctl.flagTree.SecurityContextFilePath, "security-context-file-path", defaults.SecurityContextFilePath, "Absolute path to a file containing a map of pod names to security contexts runAsUser, fsGroup, and runAsGroup")
-	cmd.Flags().BoolVar(&ctl.flagTree.IsAzure, "is-azure", defaults.IsAzure, "Whether to deploy in Azure")
+	cmd.Flags().BoolVar(&ctl.flagTree.IsAzure, "is-azure", defaults.IsAzure, "If true, deployment will be configured for Azure")
 }
 
 func isValidSize(size string) bool {

--- a/pkg/blackduck/ctl_blackduck_test.go
+++ b/pkg/blackduck/ctl_blackduck_test.go
@@ -472,6 +472,18 @@ func TestSetCRSpecFieldByFlag(t *testing.T) {
 				},
 			},
 		},
+		// case
+		{
+			flagName: "is-azure",
+			changedCtl: &HelmValuesFromCobraFlags{
+				flagTree: FlagTree{
+					IsAzure: false,
+				},
+			},
+			changedArgs: map[string]interface{}{
+				"isAzure": false,
+			},
+		},
 	}
 
 	// get the flagset


### PR DESCRIPTION
In order to support the new values.yml property `isAzure: false`

There needs to be a corresponding new command line property for synoposysctl, `--is-azure` with a setting of `true` or `false`. Default is `false`