### PR TITLE
HUB-31081: deletes webui for 2021.8.1 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ kubectl expose svc -n bd bd-blackduck-webserver --type LoadBalancer --name webse
 kubectl get svc -n bd webserver-exposed-443-8443
 ```
 
-### Upgrade to 2021.8.1 and above
-When upgrading to Blackduck versions 2021.8.1 and above, need to run the following command to delete the webui service before performing helm upgrade.
+### Upgrade to 2021.8.1 and above using native command
+For customers using native command to deploy Black Duck, when upgrading to Black Duck versions 2021.8.1 and above, need to run the following command to delete the webui service before performing helm upgrade.
 ```
 kubectl -n <namespace> delete service <namespace>-blackduck-webui
 ```

--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ kubectl expose svc -n bd bd-blackduck-webserver --type LoadBalancer --name webse
 # access the external-ip at https://EXTERNAL_IP
 kubectl get svc -n bd webserver-exposed-443-8443
 ```
+
+### Upgrade to 2021.8.1 and above
+When upgrading to Blackduck versions 2021.8.1 and above, need to run the following command to delete the webui service before performing helm upgrade.
+```
+kubectl -n <namespace> delete service <namespace>-blackduck-webui
+```

--- a/pkg/synopsysctl/cmd_delete.go
+++ b/pkg/synopsysctl/cmd_delete.go
@@ -148,8 +148,8 @@ var deleteBlackDuckCmd = &cobra.Command{
 					return fmt.Errorf("couldn't delete service '%s' in namespace '%s' due to %+v", svc.Name, namespace, err)
 				}
 			}
-			// delete webui service for versions 2021.8.1 and above, as <name>-blackduck-webui is renamed to <name>-blackduck-ui
-			if strings.HasSuffix(svc.Name, "-blackduck-webui") && (util.CompareVersions(globals.BlackDuckVersion, "2021.8.1") >= 0) {
+			// delete webui service
+			if strings.HasSuffix(svc.Name, "-blackduck-webui") {
 				if err := util.DeleteService(kubeClient, namespace, svc.Name); err != nil && !k8serrors.IsNotFound(err) {
 					return fmt.Errorf("couldn't delete webui service '%s' in namespace '%s' due to %+v", svc.Name, namespace, err)
 				}

--- a/pkg/synopsysctl/cmd_delete.go
+++ b/pkg/synopsysctl/cmd_delete.go
@@ -137,15 +137,21 @@ var deleteBlackDuckCmd = &cobra.Command{
 		}
 
 		labelSelector := fmt.Sprintf("app=%s, name=%s", util.BlackDuckName, args[0])
-		// delete exposed service
 		svcs, err := util.ListServices(kubeClient, namespace, labelSelector)
 		if err != nil {
 			return fmt.Errorf("couldn't list services in namespace '%s' due to %+v", namespace, err)
 		}
 		for _, svc := range svcs.Items {
+			// delete exposed service
 			if strings.HasSuffix(svc.Name, "-exposed") {
 				if err := util.DeleteService(kubeClient, namespace, svc.Name); err != nil && !k8serrors.IsNotFound(err) {
 					return fmt.Errorf("couldn't delete service '%s' in namespace '%s' due to %+v", svc.Name, namespace, err)
+				}
+			}
+			// delete webui service for versions 2021.8.1 and above, as <name>-blackduck-webui is renamed to <name>-blackduck-ui
+			if strings.HasSuffix(svc.Name, "-blackduck-webui") && (util.CompareVersions(globals.BlackDuckVersion, "2021.8.1") >= 0) {
+				if err := util.DeleteService(kubeClient, namespace, svc.Name); err != nil && !k8serrors.IsNotFound(err) {
+					return fmt.Errorf("couldn't delete webui service '%s' in namespace '%s' due to %+v", svc.Name, namespace, err)
 				}
 			}
 		}


### PR DESCRIPTION
For native Blackduck customers, the <name>-blackduck-webui service needs to be deleted for versions 2021.8.1 and above.