### PR TITLE
HUB-31385: Add PG 11 container support

### DIFF
--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -485,6 +485,7 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 				securityContextIDNameToHelmPath := map[string][]string{
 					"blackduck-postgres":          {"postgres", "podSecurityContext"},
 					"blackduck-postgres-upgrader": {"postgresUpgrader", "podSecurityContext"},
+					"blackduck-postgres-waiter":   {"postgresWaiter", "securityContext"},
 					"blackduck-init":              {"init", "securityContext"},
 					"blackduck-authentication":    {"authentication", "podSecurityContext"},
 					"blackduck-binnaryscanner":    {"binaryscanner", "podSecurityContext"},

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -60,6 +60,7 @@ type FlagTree struct {
 	ExposeService   string
 	ExposedNodePort string
 
+	RunPostgresMigration          bool
 	ExternalPostgresHost          string
 	ExternalPostgresPort          int
 	ExternalPostgresAdmin         string
@@ -112,6 +113,7 @@ var DefaultFlagTree = FlagTree{
 	// Expose UI
 	ExposeService: util.NONE,
 	// Postgres
+	RunPostgresMigration: false,
 	ExternalPostgresPort: 5432,
 	ExternalPostgresUser: "blackduck_user",
 	ExternalPostgresSsl:  "true",
@@ -330,6 +332,7 @@ func (ctl *HelmValuesFromCobraFlags) VerifyChartVersionSupportsChangedFlags(flag
 	if flagset.Lookup("is-azure").Changed && (util.CompareVersions(version, "2021.2.1") < 0) {
 		return fmt.Errorf("--is-azure is not supported in Black Duck versions before 2021.2.1")
 	}
+
 	return nil
 }
 
@@ -480,25 +483,26 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 					return
 				}
 				securityContextIDNameToHelmPath := map[string][]string{
-					"blackduck-postgres":       {"postgres", "podSecurityContext"},
-					"blackduck-init":           {"init", "securityContext"},
-					"blackduck-authentication": {"authentication", "podSecurityContext"},
-					"blackduck-binnaryscanner": {"binaryscanner", "podSecurityContext"},
-					"blackduck-cfssl":          {"cfssl", "podSecurityContext"},
-					"blackduck-documentation":  {"documentation", "podSecurityContext"},
-					"blackduck-jobrunner":      {"jobrunner", "podSecurityContext"},
-					"blackduck-rabbitmq":       {"rabbitmq", "podSecurityContext"},
-					"blackduck-registration":   {"registration", "podSecurityContext"},
-					"blackduck-scan":           {"scan", "podSecurityContext"},
-					"blackduck-uploadcache":    {"uploadcache", "podSecurityContext"},
-					"blackduck-webapp":         {"webapp", "podSecurityContext"},
-					"blackduck-logstash":       {"logstash", "securityContext"},
-					"blackduck-nginx":          {"webserver", "podSecurityContext"},
-					"appcheck-worker":          {"binaryscanner", "podSecurityContext"},
-					"blackduck-redis":          {"redis", "podSecurityContext"},
-					"blackduck-bomengine":      {"bomengine", "podSecurityContext"},
-					"blackduck-matchengine":    {"matchengine", "podSecurityContext"},
-					"blackduck-webui":          {"webui", "podSecurityContext"},
+					"blackduck-postgres":          {"postgres", "podSecurityContext"},
+					"blackduck-postgres-upgrader": {"postgresUpgrader", "podSecurityContext"},
+					"blackduck-init":              {"init", "securityContext"},
+					"blackduck-authentication":    {"authentication", "podSecurityContext"},
+					"blackduck-binnaryscanner":    {"binaryscanner", "podSecurityContext"},
+					"blackduck-cfssl":             {"cfssl", "podSecurityContext"},
+					"blackduck-documentation":     {"documentation", "podSecurityContext"},
+					"blackduck-jobrunner":         {"jobrunner", "podSecurityContext"},
+					"blackduck-rabbitmq":          {"rabbitmq", "podSecurityContext"},
+					"blackduck-registration":      {"registration", "podSecurityContext"},
+					"blackduck-scan":              {"scan", "podSecurityContext"},
+					"blackduck-uploadcache":       {"uploadcache", "podSecurityContext"},
+					"blackduck-webapp":            {"webapp", "podSecurityContext"},
+					"blackduck-logstash":          {"logstash", "securityContext"},
+					"blackduck-nginx":             {"webserver", "podSecurityContext"},
+					"appcheck-worker":             {"binaryscanner", "podSecurityContext"},
+					"blackduck-redis":             {"redis", "podSecurityContext"},
+					"blackduck-bomengine":         {"bomengine", "podSecurityContext"},
+					"blackduck-matchengine":       {"matchengine", "podSecurityContext"},
+					"blackduck-webui":             {"webui", "podSecurityContext"},
 				}
 				for k, v := range securityContexts {
 					pathToHelmValue := []string{k, "podSecurityContext"}                  // default path for new pods
@@ -556,24 +560,27 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 // in the Helm Chart for each image in imageRegistries
 func SetBlackDuckImageRegistriesInHelmValuesMap(helmValues map[string]interface{}, imageRegistries []string) {
 	imageNameToHelmPath := map[string][]string{
-		"postgresql-96-centos7":    {"postgres"},
-		"synopsys-init":            {"init"},
-		"blackduck-authentication": {"authentication"},
-		"bdba-worker":              {"binaryscanner"},
-		"blackduck-cfssl":          {"cfssl"},
-		"blackduck-documentation":  {"documentation"},
-		"blackduck-jobrunner":      {"jobrunner"},
-		"rabbitmq":                 {"rabbitmq"},
-		"blackduck-registration":   {"registration"},
-		"blackduck-scan":           {"scan"},
-		"blackduck-upload-cache":   {"uploadcache"},
-		"blackduck-webapp":         {"webapp"},
-		"blackduck-logstash":       {"logstash"},
-		"blackduck-nginx":          {"webserver"},
-		"blackduck-redis":          {"redis"},
-		"blackduck-bomengine":      {"bomengine"},
-		"blackduck-matchengine":    {"matchengine"},
-		"blackduck-webui":          {"webui"},
+		"postgresql-96-centos7":       {"postgres"},
+		"synopsys-init":               {"init"},
+		"blackduck-postgres":          {"postgres"},
+		"blackduck-postgres-upgrader": {"postgresUpgrader"},
+		"blackduck-postgres-waiter":   {"postgresWaiter"},
+		"blackduck-authentication":    {"authentication"},
+		"bdba-worker":                 {"binaryscanner"},
+		"blackduck-cfssl":             {"cfssl"},
+		"blackduck-documentation":     {"documentation"},
+		"blackduck-jobrunner":         {"jobrunner"},
+		"rabbitmq":                    {"rabbitmq"},
+		"blackduck-registration":      {"registration"},
+		"blackduck-scan":              {"scan"},
+		"blackduck-upload-cache":      {"uploadcache"},
+		"blackduck-webapp":            {"webapp"},
+		"blackduck-logstash":          {"logstash"},
+		"blackduck-nginx":             {"webserver"},
+		"blackduck-redis":             {"redis"},
+		"blackduck-bomengine":         {"bomengine"},
+		"blackduck-matchengine":       {"matchengine"},
+		"blackduck-webui":             {"webui"},
 	}
 
 	for _, image := range imageRegistries {


### PR DESCRIPTION
In the "blackduck update" command, add a step that checks if the database
needs to be upgraded to PG 11.  If it does, stop the Black Duck instance and
run the database migration job.