### PR TITLE
HUB-33161: fixed an error when upgrading blackduck with external db

### DIFF
--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -391,11 +391,8 @@ var updateBlackDuckCmd = &cobra.Command{
 
 func runPostgresMigration(blackDuckName string, blackDuckNamespace string, oldVersion string, newVersion string, helmValuesMap map[string]interface{}) error {
 	// If this instance is not using the PG container, do nothing and return
-	isExternal := util.GetHelmValueFromMap(helmValuesMap, []string{"postgres", "isExternal"})
-	if isExternal == nil {
-		return fmt.Errorf("postgres.isExternal must be specified")
-	}
-	if isExternal.(bool) {
+	isExternal := util.GetHelmValueFromMap(helmValuesMap, []string{"postgres", "host"}) != nil
+	if isExternal {
 		return nil
 	}
 


### PR DESCRIPTION
Fixed the error of "ERRO[0003] synopsyctl failed: postgres.isExternal must be specified"