### PR TITLE
HUB-33966: fixes the synopsysctl install issue in blackduck 2022.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/api/.DS_Store
 cmd/synopsysctl/*.key
 _output/*
 synopsysctl
+config.json

--- a/README.md
+++ b/README.md
@@ -71,3 +71,6 @@ For customers using native command to deploy Black Duck, when upgrading Black Du
 kubectl -n <namespace> delete deployment <namespace>-blackduck-webui
 kubectl -n <namespace> delete service <namespace>-blackduck-webui
 ```
+
+### Upgrade to 2022.4.0 and above
+Black Duck version 2022.4.0 introduces new resource guidance. Synopsysctl 3.0.1 and above must be used, when upgrading Black Duck to version 2022.4.0 and above.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ go run main.go create blackduck $NS \
   --certificate-file-path tls.crt \
   --certificate-key-file-path tls.key \
   --verbose-level trace \
-  --size small
+  --size 10sph
 ```
 
 This will take a few minutes, so please be patient and watch `kubectl get pods -A`!

--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-version=3.0.0-DEV-SNAPSHOT
+version=4.0.0-DEV-SNAPSHOT

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -184,7 +184,7 @@ func (ctl *HelmValuesFromCobraFlags) AddCobraFlagsToCommand(cmd *cobra.Command, 
 		cmd.Flags().StringVar(&ctl.flagTree.PersistentStorage, "persistent-storage", defaults.PersistentStorage, "If true, Black Duck has persistent storage [true|false]")
 		cmd.Flags().StringVar(&ctl.flagTree.PVCFilePath, "pvc-file-path", defaults.PVCFilePath, "Absolute path to a file containing a list of PVC json structs")
 	}
-	cmd.Flags().StringVar(&ctl.flagTree.Size, "size", defaults.Size, "Size of Black Duck [10sph|120sph|250sph|500sph|1000sph|1500sph|2000sph]")
+	cmd.Flags().StringVar(&ctl.flagTree.Size, "size", defaults.Size, "Size of Black Duck [small|medium|large|x-large|10sph|120sph|250sph|500sph|1000sph|1500sph|2000sph]")
 	cmd.Flags().StringVar(&ctl.flagTree.DeploymentResourcesFilePath, "deployment-resources-file-path", defaults.DeploymentResourcesFilePath, "Absolute path to a file containing a list of deployment Resources json structs\n")
 
 	// Expose UI

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -184,7 +184,7 @@ func (ctl *HelmValuesFromCobraFlags) AddCobraFlagsToCommand(cmd *cobra.Command, 
 		cmd.Flags().StringVar(&ctl.flagTree.PersistentStorage, "persistent-storage", defaults.PersistentStorage, "If true, Black Duck has persistent storage [true|false]")
 		cmd.Flags().StringVar(&ctl.flagTree.PVCFilePath, "pvc-file-path", defaults.PVCFilePath, "Absolute path to a file containing a list of PVC json structs")
 	}
-	cmd.Flags().StringVar(&ctl.flagTree.Size, "size", defaults.Size, "Size of Black Duck [small|medium|large|x-large]")
+	cmd.Flags().StringVar(&ctl.flagTree.Size, "size", defaults.Size, "Size of Black Duck [10sph|120sph|250sph|500sph|1000sph|1500sph|2000sph]")
 	cmd.Flags().StringVar(&ctl.flagTree.DeploymentResourcesFilePath, "deployment-resources-file-path", defaults.DeploymentResourcesFilePath, "Absolute path to a file containing a list of deployment Resources json structs\n")
 
 	// Expose UI
@@ -238,24 +238,14 @@ func (ctl *HelmValuesFromCobraFlags) AddCobraFlagsToCommand(cmd *cobra.Command, 
 	cmd.Flags().BoolVar(&ctl.flagTree.IsAzure, "is-azure", defaults.IsAzure, "If true, deployment will be configured for Azure")
 }
 
-func isValidSize(size string) bool {
-	switch strings.ToLower(size) {
-	case
-		"",
-		"small",
-		"medium",
-		"large",
-		"x-large":
-		return true
-	}
-	return false
-}
-
 // CheckValuesFromFlags returns an error if a value stored in the struct will not be able to be used
-func (ctl *HelmValuesFromCobraFlags) CheckValuesFromFlags(flagset *pflag.FlagSet) error {
+func (ctl *HelmValuesFromCobraFlags) CheckValuesFromFlags(flagset *pflag.FlagSet, version string) error {
 	if FlagWasSet(flagset, "size") {
-		if !isValidSize(ctl.flagTree.Size) {
-			return fmt.Errorf("size must be 'small', 'medium', 'large' or 'x-large'")
+		if len(ctl.flagTree.Size) > 0 {
+			_, err := util.GetSizeYAMLFileName(ctl.flagTree.Size, version)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if FlagWasSet(flagset, "expose-ui") {
@@ -347,7 +337,7 @@ func FlagWasSet(flagset *pflag.FlagSet, flagName string) bool {
 // GenerateHelmFlagsFromCobraFlags checks each flag in synopsysctl and updates the map to
 // contain the corresponding helm chart field and value
 func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pflag.FlagSet) (map[string]interface{}, error) {
-	err := ctl.CheckValuesFromFlags(flagset)
+	err := ctl.CheckValuesFromFlags(flagset, globals.BlackDuckVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/blackduck/ctl_blackduck_test.go
+++ b/pkg/blackduck/ctl_blackduck_test.go
@@ -96,6 +96,18 @@ func TestSetCRSpecFieldByFlag(t *testing.T) {
 		},
 		// case
 		{
+			flagName: "size",
+			changedCtl: &HelmValuesFromCobraFlags{
+				flagTree: FlagTree{
+					Size: "10sph",
+				},
+			},
+			changedArgs: map[string]interface{}{
+				"size": "10sph",
+			},
+		},
+		// case
+		{
 			flagName: "expose-ui",
 			changedCtl: &HelmValuesFromCobraFlags{
 				flagTree: FlagTree{

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -374,7 +374,11 @@ var createBlackDuckCmd = &cobra.Command{
 		}
 		size, found := helmValuesMap["size"]
 		if found && len(size.(string)) > 0 {
-			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", strings.ToLower(size.(string))))
+			yml, err := util.GetSizeYAMLFileName(size.(string), globals.BlackDuckVersion)
+			if err != nil {
+				return err
+			}
+			extraFiles = append(extraFiles, yml)
 		}
 
 		// Create initial resources
@@ -493,7 +497,11 @@ var createBlackDuckNativeCmd = &cobra.Command{
 		}
 		size, found := helmValuesMap["size"]
 		if found && len(size.(string)) > 0 {
-			extraFiles = append(extraFiles, fmt.Sprintf("%s.yaml", strings.ToLower(size.(string))))
+			yml, err := util.GetSizeYAMLFileName(size.(string), globals.BlackDuckVersion)
+			if err != nil {
+				return err
+			}
+			extraFiles = append(extraFiles, yml)
 		}
 
 		// Create initial resources

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -281,10 +281,18 @@ var updateBlackDuckCmd = &cobra.Command{
 
 		var sizeYAMLFileNameInChart string
 		if cmd.Flag("size").Changed {
-			sizeYAMLFileNameInChart = fmt.Sprintf("%s.yaml", cmd.Flag("size").Value.String())
+			yml, err := util.GetSizeYAMLFileName(cmd.Flag("size").Value.String(), globals.BlackDuckVersion)
+			if err != nil {
+				return err
+			}
+			sizeYAMLFileNameInChart = yml
 		} else {
 			if size, found := instance.Config["size"]; found && len(size.(string)) > 0 {
-				sizeYAMLFileNameInChart = fmt.Sprintf("%s.yaml", size.(string))
+				yml, err := util.GetSizeYAMLFileName(size.(string), globals.BlackDuckVersion)
+				if err != nil {
+					return err
+				}
+				sizeYAMLFileNameInChart = yml
 			}
 		}
 

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -734,8 +734,7 @@ func GetSizeYAMLFileName(size string, version string) (string, error) {
 		} else if isValidGen03Size(size) {
 			return fmt.Sprintf("sizes-gen03/%s.yaml", strings.ToLower(size)), nil
 		} else {
-			return "", fmt.Errorf("sizes-gen02 must be 'small', 'medium', 'large' or 'x-large'; " +
-				"sizes-gen03 must be '10sph', '120sph', '250sph', '500sph', '1000sph', '1500sph' or '2000sph'")
+			return "", fmt.Errorf("size must be 'small', 'medium', 'large', 'x-large', '10sph', '120sph', '250sph', '500sph', '1000sph', '1500sph' or '2000sph'")
 		}
 	}
 }

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -693,3 +693,49 @@ func setStringPtrInHelmValueInMap(valueMapPointer map[string]interface{}, keyLis
 		SetHelmValueInMap(valueMapPointer, keyList, *value)
 	}
 }
+
+func isValidGen02Size(size string) bool {
+	switch strings.ToLower(size) {
+	case
+		"small",
+		"medium",
+		"large",
+		"x-large":
+		return true
+	}
+	return false
+}
+
+func isValidGen03Size(size string) bool {
+	switch strings.ToLower(size) {
+	case
+		"10sph",
+		"120sph",
+		"250sph",
+		"500sph",
+		"1000sph",
+		"1500sph",
+		"2000sph":
+		return true
+	}
+	return false
+}
+
+func GetSizeYAMLFileName(size string, version string) (string, error) {
+	if CompareVersions(version, "2022.4.0") < 0 {
+		if isValidGen02Size(size) {
+			return fmt.Sprintf("%s.yaml", strings.ToLower(size)), nil
+		} else {
+			return "", fmt.Errorf("size must be 'small', 'medium', 'large' or 'x-large'")
+		}
+	} else {
+		if isValidGen02Size(size) {
+			return fmt.Sprintf("sizes-gen02/%s.yaml", strings.ToLower(size)), nil
+		} else if isValidGen03Size(size) {
+			return fmt.Sprintf("sizes-gen03/%s.yaml", strings.ToLower(size)), nil
+		} else {
+			return "", fmt.Errorf("sizes-gen02 must be 'small', 'medium', 'large' or 'x-large'; " +
+				"sizes-gen03 must be '10sph', '120sph', '250sph', '500sph', '1000sph', '1500sph' or '2000sph'")
+		}
+	}
+}


### PR DESCRIPTION
This MR is to fix the installation error in blackduck 2022.4.0

Since blackduck 2022.4.0, we introduce new resource guidance for Kubernetes files, where old sizes (small, large etc) are in sizes-gen02 folder and new sizes (10sph, 100sph etc) are in sizes-gen03 folder.

This MR is to allow users using both resource guidances without issues.